### PR TITLE
Add support for Babel ES6 JavaScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = {
         case "Ruby Haml":
         case "JavaScript":
         case "JavaScript (JSX)":
+        case "Babel ES6 JavaScript":
         case "SCSS":
         case "PHP":
           this.insertCommentHeader(editor, "// ");


### PR DESCRIPTION
Add support for "Babel ES6 JavaScript".

Closes #6 
